### PR TITLE
before_actionでイベントをセット

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,4 +1,5 @@
 class EventsController < ApplicationController
+  before_action :set_event, only: [:show, :update, :edit, :destroy]
 
 	def new
     # イベントを登録
@@ -65,18 +66,12 @@ class EventsController < ApplicationController
     end
 
     def show
-        binding.pry
-    	@event = Event.find_by(params.permit[:id])
     end
 
     def edit
-    	@event = Event.find_by(params[:id])
     end
 
     def update
-        # イベント情報を取得
-         @event = Event.find_by(params[:id])
-
         # ipアドレスを取得
          @remote_ip = request.remote_ip
 
@@ -97,7 +92,6 @@ class EventsController < ApplicationController
     end
 
     def destroy
-		@event = Event.find_by(params[:id])
         @event.destroy
         redirect_to events_path
     end
@@ -146,4 +140,9 @@ class EventsController < ApplicationController
         params.require(:date).permit(:datetime_eq)
         params.require(:date_and_keyword).permit
     end
+
+    def set_event
+        @event = Event.find_by(id: params[:id])
+    end
+
 end


### PR DESCRIPTION
* イベント取得の書き方を変更しました。
    * `@event = Event.find_by(params.permit[:id])` -> `@event = Event.find_by(id: params[:id])`
    * 参考：[findとfind_byの違いについて](https://udemy.benesse.co.jp/development/rails-find.html)
* `show, edit, update, destroy` でイベント取得しているので、before_actionにまとめました。
    * showなどが呼ばれる前に、`set_event` を通るようになります。

> 自分の環境ではこれで動いたように見えます。
> `unpermitted parameterでエラー` というのがどこのことか分からないので、見当違いでしたらすみません。

